### PR TITLE
speed up import of json reports with RcppSimdJson::fload

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: A set of tools for analyzing data associated with the Mosquito Aler
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Suggests: 
     covr,
     testthat (>= 3.0.0)
@@ -31,4 +31,5 @@ Imports:
     utils,
     stats,
     curl,
-    tools
+    tools,
+    RcppSimdJson

--- a/R/get_malert_data.R
+++ b/R/get_malert_data.R
@@ -23,12 +23,13 @@ get_malert_data = function(source = "zenodo", doi = "10.5281/zenodo.597466"){
     } else{
   stop("Error: This function currently only supports downloads from Github or Zenodo")
 }
-    reports = bind_rows(lapply(2014:lubridate::year(lubridate::today()), function(this_year){
-      print(this_year)
-      flush.console()
-      this_file = paste0("home/webuser/webapps/tigaserver/static/all_reports", this_year, ".json")
-      jsonlite::fromJSON(unz(temp, file = this_file), flatten = TRUE) %>% as_tibble()
-    }))
-    unlink(this_temp_file)
-    return(reports)
+  unzip(temp, exdir = dirname(temp))
+  reports_file_list = list.files(dirname(temp), recursive = TRUE, pattern = "all_reports[0-9]{4}.json", full.names = TRUE)
+  reports = bind_rows(lapply(reports_file_list, function(this_file){
+    print(regmatches(basename(this_file), regexpr("[0-9]{4}", basename(this_file))))
+    flush.console()
+    RcppSimdJson::fload(this_file, flatten = TRUE, max_simplify_lvl = "data_frame") %>% as_tibble()
+  }))
+  unlink(file.path(dirname(temp), "/home"), recursive = TRUE)
+  return(reports)
 }


### PR DESCRIPTION
Hi @JohnPalmer , I have replaced the `jsonlite::fromJSON()` with substantially faster `RcppSimdJson::fload()` (see https://github.com/eddelbuettel/rcppsimdjson ) to speed up the `mosquitoR::get_malert_data()`. I have not measured, but it feels 2-3 times faster and will get more noticeable with every additional year of data.

One caveat, is that the flattening strategy of `RcppSimdJson::fload()` is different from `jsonlite::fromJSON()`, which results in a slightly different data structure of the output tibble. I don't know if this change would break any of the existing workflows.